### PR TITLE
Add support for boolean, number and array frontmatter

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -28,6 +28,8 @@ export default class SuperchargedLinks extends Plugin {
 					const value = parseFrontMatterEntry(targetCachedFile.frontmatter, key)
 					if(typeof value === 'string'){
 						new_props[key] = value
+					} else if (typeof value === 'boolean'){
+						new_props[key] = value.toString()
 					}
 				}
 			})

--- a/main.ts
+++ b/main.ts
@@ -122,13 +122,16 @@ class SuperchargedLinksSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName('Target Attributes')
-			.setDesc('Frontmatter attributes to target')
-			.addText(text => text
+			.setDesc('Frontmatter attributes to target, comma separated')
+			.addTextArea((text) => {text
 				.setPlaceholder('Enter attributes as string, comma separated')
 				.setValue(this.plugin.settings.targetAttributes.join(', '))
 				.onChange(async (value) => {
 					this.plugin.settings.targetAttributes = value.replace(/\s/g,'').split(',');
 					await this.plugin.saveSettings();
-				}));
+				})
+				text.inputEl.rows = 6;
+				text.inputEl.cols = 25;
+			});
 	}
 }

--- a/main.ts
+++ b/main.ts
@@ -30,6 +30,8 @@ export default class SuperchargedLinks extends Plugin {
 						new_props[key] = value
 					} else if (typeof value === 'boolean'){
 						new_props[key] = value.toString()
+					} else if (Array.isArray(value)) {
+						new_props[key] = value.join(', ')
 					}
 				}
 			})

--- a/main.ts
+++ b/main.ts
@@ -28,7 +28,7 @@ export default class SuperchargedLinks extends Plugin {
 					const value = parseFrontMatterEntry(targetCachedFile.frontmatter, key)
 					if(typeof value === 'string'){
 						new_props[key] = value
-					} else if (typeof value === 'boolean'){
+					} else if (typeof value === 'boolean' || typeof value === 'number'){
 						new_props[key] = value.toString()
 					} else if (Array.isArray(value)) {
 						new_props[key] = value.join(', ')


### PR DESCRIPTION
Not sure how open you are to contribution, but I forked this repo and made this change for myself because I wanted to use boolean and array frontmatter with this plugin.

I tested this with my personal vault and it does appear to work.

To add CSS styling to notes where a frontmatter array `foo` contains value `bar`, you'll want to use an asterisk in the .css file, like so: `a.internal-link[data-link-foo*="bar"]`. As per https://css-tricks.com/almanac/selectors/a/attribute/.