### PR TITLE
Allow using inline field in bigger than 67kb files

### DIFF
--- a/src/settings/SuperchargedLinksSettingTab.ts
+++ b/src/settings/SuperchargedLinksSettingTab.ts
@@ -81,7 +81,7 @@ export default class SuperchargedLinksSettingTab extends PluginSettingTab {
 		// Managing choice wether you get attributes from inline fields and frontmatter or only frontmater
 		new Setting(containerEl)
 		.setName('Search for attribute in Inline fields like <field::>')
-		.setDesc('Searching for attribute in Inline fields may fail with large files (67k+ chars)')
+		.setDesc('Sets the `data-link-<field>`-attribute to the value of inline fields')
 		.addToggle(toggle => {
 			toggle.setValue(this.plugin.settings.getFromInlineField)
 				toggle.onChange(value => {
@@ -89,7 +89,7 @@ export default class SuperchargedLinksSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings()
 				})
 		})
-        
+
         /* Managing predefined values for properties */
 		/* Manage menu options display*/
 		new Setting(containerEl)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
       "dom",
       "es5",
       "scripthost",
-      "es2015"
+      "es2020"
     ]
   },
   "include": [


### PR DESCRIPTION
This PR is similar to #21 but it fixes several things:
- Bigger than 67kb files are now parsed correctly for linline fields.
- When parsing for inline fields, we `await` its parsing to avoid making two passes for it.
- Less and simpler code with only one regex for the whole file.

And as the warning for 67k+ chars file is no longer relevant, replaces it with a standard explanation.

However, in order to make the code work with `matchAll`, I had to update the `lib` entry in the `tsconfig.json` to `es2020` but I don't think it's an issue for obsidian.