### PR TITLE
Make SL work with `Another Quick Switcher` again

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -144,7 +144,7 @@ export default class SuperchargedLinks extends Plugin {
 							(n.className.includes('modal-container') && plugin.settings.enableQuickSwitcher
 								// @ts-ignore
 								|| n.className.includes('suggestion-container') && plugin.settings.enableSuggestor)) {
-							let selector = ".suggestion-item, .suggestion-note, .another-quick-switcher__item__file";
+							let selector = ".suggestion-item, .suggestion-note, .another-quick-switcher__item__title";
 							// @ts-ignore
 							if (n.className.includes('suggestion-container')) {
 								selector = ".suggestion-content, .suggestion-note";


### PR DESCRIPTION
fixes #100. 

Another Quick Switcher simply seems to have changed the name of their css class. Wasn't aware that fixing the issue would be so easy 😆 If I knew that, I'd have done it myself a lot earlier already.