### PR TITLE
[WIP] Supercharging Graph View

### DIFF
--- a/src/cssBuilder/cssLink.ts
+++ b/src/cssBuilder/cssLink.ts
@@ -66,9 +66,9 @@ class CSSLink {
         //return id of format 'aaaaaaaa'-'aaaa'-'aaaa'-'aaaa'-'aaaaaaaaaaaa'
         this.uid = s4() + "-" + s4();
         this.selectText = true;
+        this.selectBackground = true;
         this.selectAppend = true;
         this.selectPrepend = true;
-        this.selectBackground = true;
     }
 }
 

--- a/src/settings/SuperchargedLinksSettingTab.ts
+++ b/src/settings/SuperchargedLinksSettingTab.ts
@@ -104,6 +104,16 @@ Styling can be done using the Style Settings plugin.
 					this.plugin.saveSettings()
 				});
 			});
+		new Setting(containerEl)
+			.setName('Enable in Graph View')
+			.setDesc('If true, this will also supercharge graph views.')
+			.addToggle(toggle => {
+				toggle.setValue(this.plugin.settings.enableGraph)
+				toggle.onChange(value => {
+					this.plugin.settings.enableGraph = value
+					this.plugin.saveSettings()
+				});
+			});
 
 		containerEl.createEl('h4', {text: 'Advanced'});
 		// Managing choice wether you want to parse tags both from normal tags and in the frontmatter

--- a/src/settings/SuperchargedLinksSettings.ts
+++ b/src/settings/SuperchargedLinksSettings.ts
@@ -15,6 +15,7 @@ export interface SuperchargedLinksSettings {
 	enableBacklinks: boolean;
 	enableQuickSwitcher: boolean;
 	enableSuggestor: boolean;
+	enableGraph: boolean;
 	selectors: CSSLink[];
 }
 
@@ -32,5 +33,6 @@ export const DEFAULT_SETTINGS: SuperchargedLinksSettings = {
 	enableBacklinks: true,
 	enableQuickSwitcher: true,
 	enableSuggestor: true,
+	enableGraph: true,
 	selectors: []
 }


### PR DESCRIPTION
So I've started working on the solution. Right now this is:

* :adhesive_bandage: hacky
* :snail: inefficient
* :gear: doesn't cover attributes
* :lady_beetle: untested

I've marked several issues with `// TODO`-s and `// FIXME`-s, but I'd still like to get some input on this, especially regarding (but of course not limited to) :memo::

* The location this code should go to
* The idea of abstracting away property names (or not only names)

Most of the styling is dealt by CSS rules. Graphs are canvas-based, so the styling is made by hand. So it's logical that this feature implementation would definitely have a different form than everything else, and you know better than me how this should be factored :smiley:.

Oh, by the way, I didn't really dive into `MetadataCache` part of Obsidian API as `fetchTargetAttributesSync` saved me from that. WDYT of making that attribute set a bit stricter by replacing it with an object? It definitely was okay as it is when it was consumed in one place, but I'm a bit afraid of pulling records in public places (though I'm a bit afraid of working with such forgiving environment like TS/JS ecosystem in general, as I'm coming from much stricter Kotlin/JVM background :sweat_smile:).

By the way, this is not time-sensitive at all, as there is a chance I'll have to postpone this and continue later (but I'd like to eventually bring this to production :smile:). So take your time with checking the PR.

Closes #124.
