### PR TITLE
Fix error when cachedFile is null

### DIFF
--- a/src/linkAttributes/linkAttributes.ts
+++ b/src/linkAttributes/linkAttributes.ts
@@ -143,7 +143,7 @@ export function updateVisibleLinks(app: App, plugin: SuperchargedLinks) {
                 clearExtraAttributes(tabHeader);
             }
 
-            if (cachedFile.links) {
+            if (cachedFile?.links) {
                 cachedFile.links.forEach((link: LinkCache) => {
                     const fileName = file.path.replace(/(.*).md/, "$1")
                     const dest = app.metadataCache.getFirstLinkpathDest(link.link, fileName)


### PR DESCRIPTION
Just a quick little one-liner to fix an error that sometimes crops up when opening a new file.

<img width="826" alt="CleanShot 2022-09-29 at 10 57 26@2x" src="https://user-images.githubusercontent.com/3974347/192989172-cf818b0a-8ff9-4965-98b3-789f20247331.png">
