### PR TITLE
Fix #174

### DIFF
--- a/src/linkAttributes/livePreview.ts
+++ b/src/linkAttributes/livePreview.ts
@@ -105,7 +105,7 @@ export function buildCMViewPlugin(app: App, _settings: SuperchargedLinksSettings
                                 }
                                 if (isLink && !isAlias && !isPipe || isMDUrl) {
                                     let linkText = view.state.doc.sliceString(node.from, node.to);
-                                    linkText = decodeURI(linkText.split("#")[0]);
+                                    linkText = linkText.split("#")[0];
                                     let file = app.metadataCache.getFirstLinkpathDest(linkText, mdView.file.basename);
                                     if (isMDUrl && !file) {
                                         try {


### PR DESCRIPTION
`decodeURI()` was introduced in #157 to fix capturing links with spaces in their name ("first last.md") in live view. As of Obsidian 1.1.16 this does not seem to be a problem. Links with spaces are received as such. Replacing spaces with "%20" (URI encoding) breaks the links in Obsidian.
Links like `path and/file with spaces.md` work fine without this.
Filenames with `%` also work fine after this fix `50% of the time it works 100% of the time.md`