### PR TITLE
Fix 163

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -147,7 +147,8 @@ export default class SuperchargedLinks extends Plugin {
 	}
 
 	updateContainer(container: HTMLElement, plugin: SuperchargedLinks, selector: string) {
-		if (!plugin.settings.enableBacklinks) return;
+		if (!plugin.settings.enableBacklinks && container.getAttribute("data-type") !== "file-explorer") return;
+		if (!plugin.settings.enableFileList && container.getAttribute("data-type") === "file-explorer") return;
 		const nodes = container.findAll(selector);
 		for (let i = 0; i < nodes.length; ++i) {
 			const el = nodes[i] as HTMLElement;
@@ -176,6 +177,7 @@ export default class SuperchargedLinks extends Plugin {
 	_watchContainerDynamic(viewType: string, container: HTMLElement, plugin: SuperchargedLinks, selector: string, own_class = 'tree-item-inner', parent_class = 'tree-item') {
 		// Used for efficient updating of the backlinks panel
 		// Only loops through newly added DOM nodes instead of changing all of them
+		if (!plugin.settings.enableBacklinks) return;
 		let observer = new MutationObserver((records, _) => {
 			records.forEach((mutation) => {
 				if (mutation.type === 'childList') {

--- a/src/linkAttributes/linkAttributes.ts
+++ b/src/linkAttributes/linkAttributes.ts
@@ -108,6 +108,13 @@ export function updateDivExtraAttributes(app: App, settings: SuperchargedLinksSe
     if (!linkName) {
         linkName = link.textContent;
     }
+    if (!!link.parentElement.getAttribute('data-path')) {
+        // File Browser
+        linkName = link.parentElement.getAttribute('data-path');
+    } else if (link.parentElement.getAttribute("class") == "suggestion-content" && !!link.nextElementSibling) {
+        // Auto complete
+        linkName = link.nextElementSibling.textContent + linkName;
+    }
     const dest = app.metadataCache.getFirstLinkpathDest(getLinkpath(linkName), destName)
 
     if (dest) {
@@ -137,7 +144,7 @@ export function updateVisibleLinks(app: App, plugin: SuperchargedLinks) {
             const tabHeader: HTMLElement = leaf.tabHeaderInnerTitleEl;
             if (settings.enableTabHeader) {
                 // Supercharge tab headers
-                updateDivExtraAttributes(app, settings, tabHeader, "");
+                updateDivExtraAttributes(app, settings, tabHeader, "", file.path);
             }
             else {
                 clearExtraAttributes(tabHeader);


### PR DESCRIPTION
This fixes 163 for most cases. What I verified as working:
* Tab headers
* File Explorer
* Quick switcher
* Autocomplete
* Autocomplete w/ alias
* Quick switcher w/ alias
* Regular links in edit (source and live preview) as well as reading view

What still does not work: Links in the backlinks pane. I couldn't figure that out.

Additional fixes:
* "Enable in File Browser" previously did nothing. Now toggles supercharging the File Browser (on app reload)
* "Enable in Plugins" now correctly disables supercharging the backlinks pane (on app reload)
