### PR TITLE
Add helpUrl to manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,6 @@
 	"description": "Add properties and menu options to links and style them!",
 	"author": "mdelobelle & Emile",
 	"authorUrl": "https://github.com/mdelobelle/mdelobelle/tree/main",
+	"helpUrl": "https://github.com/mdelobelle/obsidian_supercharged_links#readme",
 	"isDesktopOnly": false
 }


### PR DESCRIPTION
I am adding helpUrl to the manifest to support the help system integration into Obsidian. Please consider supporting this initiative. Just so you know, this key value in manifest.json must be in the manifest downloaded as part of the plugin in the release.

https://forum.obsidian.md/t/links-to-help-and-manuals-for-plugins-and-themes/70733/8