### PR TITLE
feature: Add formatter to allow property values in dynamic views

### DIFF
--- a/src/settings/SuperchargedLinksSettings.ts
+++ b/src/settings/SuperchargedLinksSettings.ts
@@ -12,6 +12,9 @@ export interface SuperchargedLinksSettings {
 	enableQuickSwitcher: boolean;
 	enableSuggestor: boolean;
 	selectors: CSSLink[];
+	enableDynamicViewNameFormatting: boolean;
+	dynamicViewNameFormat: string;
+	dynamicViewNameFormatProperties: Array<string>;
 }
 
 export const DEFAULT_SETTINGS: SuperchargedLinksSettings = {
@@ -25,5 +28,8 @@ export const DEFAULT_SETTINGS: SuperchargedLinksSettings = {
 	enableBacklinks: true,
 	enableQuickSwitcher: true,
 	enableSuggestor: true,
-	selectors: []
+	selectors: [],
+	enableDynamicViewNameFormatting: false,
+	dynamicViewNameFormat: "{name}",
+	dynamicViewNameFormatProperties: []
 }


### PR DESCRIPTION
I've been using this plugin for a while and it plays a crucial part in my workflow. I implemented formatter to be able to use property values in dynamic views.

Currently it works globally applying the same formatting to all links. If this is something worthwhile, next step would be to implement per-selector formatting for more granular control.