### PR TITLE
fix: nested elements in embedded bases

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -105,7 +105,7 @@ export default class SuperchargedLinks extends Plugin {
 			plugin.registerViewType('bases', plugin, '.multi-select-pill-content');
 
 			// For embedded bases
-			plugin.registerViewType('markdown', plugin, 'div.bases-table-cell > span.internal-link');
+			plugin.registerViewType('markdown', plugin, 'div.bases-table-cell span.internal-link');
 			plugin.registerViewType('markdown', plugin, 'div.bases-table-cell div.multi-select-pill-content');
 			plugin.registerViewType('markdown', plugin, 'div.bases-cards-line');
 		}


### PR DESCRIPTION
Changes to fix nested elements in embedded bases as mentioned in: 


https://github.com/mdelobelle/obsidian_supercharged_links/issues/270#issuecomment-3657035568

> Just double checked on desktop and I can see the same issue, and can confirm that I am in 0.13.10
> 
> I think the issue is the change linked here:, in the `// For embedded bases` section [3ba49cd#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0L108-R111](https://github.com/mdelobelle/obsidian_supercharged_links/commit/3ba49cd698e4c7d332274fa7b5d8f0122743fcb5#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0L108-R111)
> 
> while the change from `a` to `span` fixed the issue for top most links in `bases-table-cell`(because the element changed in the obsidian update) the change from descendant combinator ` ` to child combinator `>` now excludes links in more nested lists and formulas (like my usecase) because they are not direct children of `bases-table-cell`
> 
> Keeping the new element `span` but reverting to the descendant combinator ` ` might fix the issue (just tested it with css and by modifying main.js )
> 
> `plugin.registerViewType('markdown', plugin, 'div.bases-table-cell span.internal-link');`