### PR TITLE
feat: add Similar Notes sidebar panel support

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -111,6 +111,7 @@ export default class SuperchargedLinks extends Plugin {
 		}
 		if (plugin.app?.plugins?.plugins?.['similar-notes']) {
 			plugin.registerViewType('markdown', plugin, '.similar-notes-pane .tree-item-inner', true)
+			plugin.registerViewType('similar-notes-sidebar', plugin, '.similar-notes-pane .tree-item-inner', true)
 		}
 		// If backlinks in editor is on
 		// @ts-ignore


### PR DESCRIPTION
Hey! Found an issue where your plugin doesn't play nice with the similar-notes plugin's right panel. This change should fix it. Take a look when you get a chance. Thanks!